### PR TITLE
Update library to Modelica 4.0.0, and correct various bugs

### DIFF
--- a/Modelica_Requirements/ChecksInFixedWindow.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow.mo
@@ -1213,7 +1213,7 @@ property = <b>WhenRising</b>(condition=..., check=...).y;
 
 <p>
 At the time instants where condition has a rising edge, property is set to 
-\"<a href=\"Modelica_Requirements.LogicalFunctions.BooleanToProperty\">BooleanToProperty</a>(check)\" (so either Satisfied or Violated)
+\"<a href=\"modelica://Modelica_Requirements.LogicalFunctions.BooleanToProperty\">BooleanToProperty</a>(check)\" (so either Satisfied or Violated)
 and keeps this value until the next rising edge. Before the first rising edge,
 property = Undecided. If condition = true during initialization, property = toProperty(check)
 at initialization. 
@@ -1301,7 +1301,7 @@ property = <b>WhenFalling</b>(condition=..., check=...).y;
 
 <p>
 At the time instants where condition has a falling edge, property is set to 
-\"<a href=\"Modelica_Requirements.LogicalFunctions.BooleanToProperty\">BooleanToProperty</a>(check)\" (so either Satisfied or Violated)
+\"<a href=\"modelica://Modelica_Requirements.LogicalFunctions.BooleanToProperty\">BooleanToProperty</a>(check)\" (so either Satisfied or Violated)
 and keeps this value until the next falling edge. Before the first falling edge,
 property = Undecided. If condition = false during initialization, property = toProperty(check)
 at initialization. 
@@ -1389,7 +1389,7 @@ property = <b>WhenChanging</b>(condition=..., check=...).y;
 
 <p>
 At the time instants where condition has a changing edge, property is set to 
-\"<a href=\"Modelica_Requirements.LogicalFunctions.BooleanToProperty\">BooleanToProperty</a>(check)\" (so either Satisfied or Violated)
+\"<a href=\"modelica://Modelica_Requirements.LogicalFunctions.BooleanToProperty\">BooleanToProperty</a>(check)\" (so either Satisfied or Violated)
 and keeps this value until the next changing edge. At initialization, property = Undecided, independently of the value of condition. 
 </p>
 

--- a/Modelica_Requirements/ChecksInFixedWindow.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow.mo
@@ -79,7 +79,7 @@ results in
     extends Modelica_Requirements.Interfaces.PartialCheck;
     import Modelica_Requirements.Types.Property;
 
-    parameter Modelica.SIunits.Time durationMin(start=1,min=0)
+    parameter Modelica.Units.SI.Time durationMin(start=1, min=0)
       "Minimum duration in true condition phase";
   protected
     discrete Real actualDuration;
@@ -210,7 +210,7 @@ results in
     extends Modelica_Requirements.Interfaces.PartialCheck;
     import Modelica_Requirements.Types.Property;
 
-    parameter Modelica.SIunits.Time durationMax(start=1,min=0)
+    parameter Modelica.Units.SI.Time durationMax(start=1, min=0)
       "Maximum duration in true condition phase";
   protected
     discrete Real actualDuration;
@@ -343,8 +343,8 @@ results in
     "In every true condition phase, check must be true for at least a minimum duration and at most a maximum duration"
     extends Modelica_Requirements.Interfaces.PartialCheck;
     import Modelica_Requirements.Types.Property;
-    parameter Modelica.SIunits.Time durationMin(start=1) "Minimum duration";
-    parameter Modelica.SIunits.Time durationMax(start=2) "Maximum duration";
+    parameter Modelica.Units.SI.Time durationMin(start=1) "Minimum duration";
+    parameter Modelica.Units.SI.Time durationMax(start=2) "Maximum duration";
   protected
     discrete Real actualDuration;
     discrete Real startTime;
@@ -1036,7 +1036,7 @@ results in
     extends Modelica_Requirements.Interfaces.PartialCheck;
     import Modelica_Requirements.Types.Property;
 
-    parameter Modelica.SIunits.Frequency freqHzMax(min=0.0)
+    parameter Modelica.Units.SI.Frequency freqHzMax(min=0.0)
       "Maximum frequency of rising edges in true condition phase";
     Modelica.Blocks.Interfaces.RealOutput freqHz(final quantity="Frequency",final unit="Hz")
       "Check rising edge frequency in true condition phase, otherwise zero"
@@ -1045,9 +1045,9 @@ results in
   protected
     constant Real eps = 100*Modelica.Constants.eps
       "Small number to guard against division of zero";
-    discrete Modelica.SIunits.Time timeOfLastRising
+    discrete Modelica.Units.SI.Time timeOfLastRising
       "Time instance of last rising edge";
-    discrete Modelica.SIunits.Time T
+    discrete Modelica.Units.SI.Time T
       "Duration between actual time and last rising";
     Boolean computeFrequency
       "= true, if frequency can be computed at the next rising";

--- a/Modelica_Requirements/ChecksInFixedWindow.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow.mo
@@ -1565,7 +1565,7 @@ results in
             fillColor=DynamicSelect({245,245,245},fillColor),
             fillPattern=FillPattern.Solid),
           Line(points=DynamicSelect({{0,0},{-140,0}}, line1),
-               lineColor=DynamicSelect({0,127,0},varColor)),
+               color=DynamicSelect({0,127,0},varColor)),
           Ellipse(
             extent=DynamicSelect({{-10,10},{10,-10}}, circle1),
             fillPattern=FillPattern.Solid,
@@ -1578,7 +1578,7 @@ results in
             fillColor={135,135,135}),
           Text(
             extent={{-250,210},{250,250}},
-            lineColor={175,175,175},
+            textColor={175,175,175},
             textString="%name")}), Diagram(coordinateSystem(preserveAspectRatio=false,
             extent={{-200,-200},{200,200}}), graphics),
       Documentation(info="<html>

--- a/Modelica_Requirements/ChecksInFixedWindow.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow.mo
@@ -1499,7 +1499,7 @@ results in
       "Polygon defining the boundary of the domain (polygon[i,2] is point i of polygon)";
 
   protected
-    type Color = Integer[3](min=0, max=255);
+    type Color = Integer[3](each min=0, each max=255);
     parameter Color inSide = {0, 127, 0} "Color when inside polygon (= green)";
     parameter Color outSide = {255, 0, 0} "Color when outside polygon (= red)";
     parameter Real icon_max = 195 "Length of x and y axis of icon";

--- a/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
@@ -102,7 +102,7 @@ the maximum amplitude Ai at frequency point fi in [Hz]. fi &ge; 0 required). The
 
 <p>
 For more details, see the description of package
-<a href=\"Modelica_Requirements.ChecksInFixedWindow_withFFT\">ChecksInFixedWindow_withFFT</a>.
+<a href=\"modelica://Modelica_Requirements.ChecksInFixedWindow_withFFT\">ChecksInFixedWindow_withFFT</a>.
 </p>
 
 
@@ -142,7 +142,7 @@ Simulating this examples results in
 
 <p>
 As can be seen, the simulation is terminate (via instance <b>terminate1</b> of block 
-<a href=\"Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
+<a href=\"modelica://Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
 the FFT has been computed (signaled via the falling edge of FFT_computation).
 Since all FFT amplitudes between 0 &le; f &le; min(f_max, maxAmplitude[end,1]) are below the maximally allowed limit,
 the block returns Property.Satisfied.
@@ -364,7 +364,7 @@ interpolated for this check.
 
 <p>
 For more details, see the description of package
-<a href=\"Modelica_Requirements.ChecksInFixedWindow_withFFT\">ChecksInFixedWindow_withFFT</a>.
+<a href=\"modelica://Modelica_Requirements.ChecksInFixedWindow_withFFT\">ChecksInFixedWindow_withFFT</a>.
 </p>
 
 
@@ -405,7 +405,7 @@ Simulating this examples results in
 
 <p>
 As can be seen, the simulation is terminate (via instance <b>terminate1</b> of block 
-<a href=\"Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
+<a href=\"modelica://Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
 the FFT has been computed (signaled via the falling edge of FFT_computation).
 Since all FFT amplitudes between 0 &le; f &le; min(f_max, maxAmplitude[end,1]) are below the maximally allowed limit,
 the block returns Property.Satisfied.
@@ -650,7 +650,7 @@ where <b>THDmax</b> is the maximum allowed THD value. The default value is 0.1 (
 
 <p>
 For more details, see the description of package
-<a href=\"Modelica_Requirements.ChecksInFixedWindow_withFFT\">ChecksInFixedWindow_withFFT</a>.
+<a href=\"modelica://Modelica_Requirements.ChecksInFixedWindow_withFFT\">ChecksInFixedWindow_withFFT</a>.
 </p>
 
 

--- a/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
@@ -1,4 +1,4 @@
-﻿within Modelica_Requirements;
+within Modelica_Requirements;
 package ChecksInFixedWindow_withFFT
   "Library of check blocks that inspect properties in a fixed time window using FFT (Fast Fourier Transform)"
   extends Modelica.Icons.Package;
@@ -212,7 +212,7 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
     "A rising condition input triggers an FFT calculation. The amplitudes of the FFTs must be below a frequency dependent limit that is defined relative to the amplitude of the base frequency"
     extends Internal.PartialFFT;
 
-    parameter Modelica.SIunits.Frequency f_base
+    parameter Modelica.Units.SI.Frequency f_base
       "Base frequency (100 % amplitude = largest amplitude around f_base)";
     parameter Real searchInterval(min=0, max=100) = 5
       "Search interval [%] around base frequency f_base for real base frequency (with largest amplitude)"
@@ -220,7 +220,7 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
     parameter Real maxAmplitude[:,2]
       "Maximum allowed amplitude: Real[:,2] array with [frequency in Hz, amplitude[%]]";
 
-    discrete Modelica.SIunits.Frequency f_base2
+    discrete Modelica.Units.SI.Frequency f_base2
       "Real base frequency (frequency with largest amplitude around f_base)";
     discrete Real A_base2
       "Amplitude at the real base frequency (= largest amplitude around f_base)";
@@ -476,7 +476,7 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
     import Modelica_Requirements.Types.Property;
     extends Internal.PartialFFT(final f_max=n_harmonics*f_base);
 
-    parameter Modelica.SIunits.Frequency f_base
+    parameter Modelica.Units.SI.Frequency f_base
       "Base frequency (100 % amplitude = largest amplitude around f_base)";
     parameter Integer n_harmonics=5
       "Number of harmonics to treat for THD (f_max = n_harmonics*f_base; sampling frequency >= 10*f_max)";
@@ -485,7 +485,7 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
       "Search interval [%] around base frequency f_base for real base frequency (with largest amplitude)"
       annotation (Dialog(tab="Advanced"));
 
-    discrete Modelica.SIunits.Frequency f_base2
+    discrete Modelica.Units.SI.Frequency f_base2
       "Real base frequency (frequency with largest amplitude around f_base)";
     discrete Real A_base2
       "Amplitude at the real base frequency (= largest amplitude around f_base)";
@@ -758,9 +758,9 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
         parameter Boolean storeFFTonFile=true
         "= true, if FFT results shall be stored on file <modelName>/FFT.<instanceName>.<index>.mat"
                                                                                        annotation(Evaluate=true, choices(checkBox=true));
-        parameter Modelica.SIunits.Frequency  f_max
+      parameter Modelica.Units.SI.Frequency f_max
         "Maximum frequency of interest (sampling frequency >= 10*f_max)";
-        parameter Modelica.SIunits.Frequency  f_resolution
+      parameter Modelica.Units.SI.Frequency f_resolution
         "Frequency resolution (frequency axis points are an integer multiple of f_resolution)";
 
         Modelica.Blocks.Interfaces.BooleanInput condition
@@ -781,19 +781,19 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
 
         final parameter Integer ns = Internal.get_ns(f_max, f_resolution)
         "Number of FFT sample points (is even and can be expressed as ns = 2^i*3^j*5^k)";
-        final parameter Modelica.SIunits.Frequency f_max_FFT = f_resolution*div(ns, 2)
-        "Maximum frequency used by FFT";
+      final parameter Modelica.Units.SI.Frequency f_max_FFT=f_resolution*div(ns,
+          2) "Maximum frequency used by FFT";
         final parameter Integer nf = div(ns,2) + 1 "Number of frequency points";
-        final parameter Modelica.SIunits.Time Ts = 1/(2*f_max_FFT)
-        "Sample period";
-        final parameter Modelica.SIunits.Time T = (ns - 1)*Ts
+      final parameter Modelica.Units.SI.Time Ts=1/(2*f_max_FFT) "Sample period";
+      final parameter Modelica.Units.SI.Time T=(ns - 1)*Ts
         "Simulation time for one FFT calculation";
         Boolean periods_ok
         "= true, if all periods for FFT computations have been long enough";
 
         final parameter Integer np = max(1,min(integer(ceil(f_max/f_resolution))+1,nf))
         "Number of frequency points used for plotting (only up to interested frequency";
-        final parameter Modelica.SIunits.Frequency f_max_plot = (np-1)*f_resolution;
+      final parameter Modelica.Units.SI.Frequency f_max_plot=(np - 1)*
+          f_resolution;
         Integer fillColor[3] = if scaledDistance >= 0 then {245,245,245} else {255,218,213};
         final Real fA_plot[3*np,2](each start=0, each fixed=true)
         "[frequency, amplitude] matrix used for plotting in icon";
@@ -941,7 +941,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
       import Modelica_Requirements.Types.Property;
 
       input Real A[:] "Amplitudes";
-      input Modelica.SIunits.Frequency f_max "Frequency value of A[n]";
+      input Modelica.Units.SI.Frequency f_max "Frequency value of A[n]";
       input Real maxAmplitude[:,2] "Maximum amplitude";
       input Boolean periods_ok;
       output Modelica_Requirements.Types.Property property;
@@ -987,8 +987,8 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
     end checkDomain;
 
     function get_ns "Return number of sample points"
-       input Modelica.SIunits.Frequency f_max "Maximum frequency of interest";
-       input Modelica.SIunits.Frequency f_resolution "Frequency resolution";
+      input Modelica.Units.SI.Frequency f_max "Maximum frequency of interest";
+      input Modelica.Units.SI.Frequency f_resolution "Frequency resolution";
        input Integer f_max_factor(min=1)=5
         "Maximum FFT frequency >= f_max*f_max_factor (sample frequency = 2*Maximum FFT Frequency)";
        output Integer ns
@@ -1143,7 +1143,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
        input String filePrefix
         "First part of file name (= FFT.<instanceNamne>.)";
        input Integer fileIndex "Index of FFT computation";
-       input Modelica.SIunits.Frequency f_max "Maximum frequency";
+      input Modelica.Units.SI.Frequency f_max "Maximum frequency";
        input Real    A[:] "Amplitude";
        input Integer iTick;
     protected
@@ -1217,7 +1217,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
       input Real u_buf[:] "Signal for which FFT shall be computed; (size(u_buf,1) MUST be EVEN and should be an integer multiple of 2,3,5, that is size(u_buf,1) = 2^a*3^b*5^c, with a,b,c Integer >= 0)";
       input Integer nf(min=1) "Number of frequency points that shall be returned in amplitudes and phases (typically: nf = max(1,min(integer(ceil(f_max/f_resolution))+1,nf_max))); the maximal possible value is nf_Max=div(size(u_buf,1),2)+1)";
       input Integer iTick "Number of sample points that have been stored in u_buf";
-      input Modelica.SIunits.Time Ts "Sample period of FFT";
+      input Modelica.Units.SI.Time Ts "Sample period of FFT";
       input Boolean pre_periods_ok "Previous value of periods_ok";
       input String instanceName="???";
       output Real A_buf[nf];
@@ -1227,9 +1227,9 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
       Integer ns = size(u_buf,1);
       Real u_buf2[size(u_buf,1)];
       Real u_DC;
-      Modelica.SIunits.Time T_req = (ns-1)*Ts
+      Modelica.Units.SI.Time T_req=(ns - 1)*Ts
         "Required period for FFT computation";
-      Modelica.SIunits.Time T_act = (iTick-1)*Ts
+      Modelica.Units.SI.Time T_act=(iTick - 1)*Ts
         "Actually used period for FFT computation";
       Integer info;
     algorithm
@@ -1402,17 +1402,17 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
     function findBaseFrequency
       "Find real base frequency (search around an interval of f_base for the largest amplitude"
       import Modelica.Utilities.Streams.print;
-      input Modelica.SIunits.Frequency f_resolution;
-      input Modelica.SIunits.Frequency f_base;
+      input Modelica.Units.SI.Frequency f_resolution;
+      input Modelica.Units.SI.Frequency f_base;
       input Real searchInterval "in [%] of f_base";
       input Real A_buf[:];
-      output Modelica.SIunits.Frequency f_baseReal;
+      output Modelica.Units.SI.Frequency f_baseReal;
       output Real A_baseReal;
       output Integer index_baseReal;
     protected
       Integer nf = size(A_buf,1);
-      Modelica.SIunits.Frequency f1;
-      Modelica.SIunits.Frequency f2;
+      Modelica.Units.SI.Frequency f1;
+      Modelica.Units.SI.Frequency f2;
       Integer i1;
       Integer i2;
       Integer j;
@@ -1499,8 +1499,8 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
 
     function baseAmplitudeForIcon
       "Determine amplitude line of base frequency for icon"
-      input Modelica.SIunits.Frequency f_baseReal;
-      input Modelica.SIunits.Frequency f_max_plot;
+      input Modelica.Units.SI.Frequency f_baseReal;
+      input Modelica.Units.SI.Frequency f_max_plot;
       input Real A_f_baseReal;
       input Real A_max_plot "Maximum amplitude in %";
       output Real line[2,2];

--- a/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
@@ -15,7 +15,7 @@ package ChecksInFixedWindow_withFFT
       "[frequency, amplitude] matrix used for plotting in icon";
 
   equation
-    when {iTick == ns, terminal() and time <= nextTime} then
+    when {iTick == ns, terminal() and time < nextTime} then
        fA_plot             = Internal.amplitudeFrequencyCurveForIcon(A_buf,A_max_plot);
        (y, scaledDistance) = Internal.checkDomain(A_buf, f_max_plot, maxAmplitude, periods_ok);
     end when;
@@ -238,7 +238,7 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
     maxAmplitude2 = zeros(size(maxAmplitude,1),2);
     maxAmplitudePlot = zeros(size(maxAmplitude,1),2);
   equation
-    when {iTick == ns, terminal() and time <= nextTime} then
+    when {iTick == ns, terminal() and time < nextTime} then
        (f_base2, A_base2)  = Internal.findBaseFrequency(f_resolution, f_base, searchInterval, A_buf);
        maxAmplitude2       = [maxAmplitude[:,1],maxAmplitude[:,2]*(A_base2/100)];
        A_max_plot          = max(maxAmplitude2[:,2]) + 0.1*A_base2;
@@ -501,7 +501,7 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
     THD = 0;
     f_base2_line = {{0,0},{0,0}};
   equation
-    when {iTick == ns, terminal() and time <= nextTime} then
+    when {iTick == ns, terminal() and time < nextTime} then
        (f_base2, A_base2, index_base2) = Internal.findBaseFrequency(f_resolution, f_base, searchInterval, A_buf);
        A_max_plot     = max(A_buf);
        f_base2_line   = Internal.baseAmplitudeForIcon(f_base2, f_max_plot, A_base2, A_max_plot);
@@ -797,7 +797,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
         Integer fillColor[3] = if scaledDistance >= 0 then {245,245,245} else {255,218,213};
         final Real fA_plot[3*np,2](each start=0, each fixed=true)
         "[frequency, amplitude] matrix used for plotting in icon";
-    protected
+      protected
         constant String instanceName =    getInstanceName();
         constant String resultDirectory = Modelica_Requirements.Internal.getFirstName(instanceName);
         constant String filePrefix =      "FFT." + Modelica_Requirements.Internal.removeFirstName(instanceName) + ".";
@@ -839,7 +839,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
         // After the value of u is stored at the last sample point or when
         // the simulation is terminated and one or more u-values already stored,
         // perform an FFT computation
-        when {iTick == ns, terminal() and time <= nextTime} then
+        when {iTick == ns, terminal() and time < nextTime} then
            (A_buf, periods_ok) = Internal.fftScaled(u_buf, np, iTick, Ts, pre(periods_ok), instanceName);
            fileIndex           = pre(fileIndex) + 1;
            if storeFFTonFile and iTick > 1 then

--- a/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
@@ -36,35 +36,35 @@ package ChecksInFixedWindow_withFFT
             points=DynamicSelect({{-260,140},{260,140}},maxAmplitudePlot), color={255,0,0}),
           Text(
             extent={{-252,-215},{-22,-245}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             horizontalAlignment=TextAlignment.Left,
             textString="0 Hz"),
           Text(
             extent={{50,-215},{280,-245}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             horizontalAlignment=TextAlignment.Right,
             textString=DynamicSelect("???", String(f_max_plot)) + " Hz"),
           Text(
             extent={{-240,185},{-15,155}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             horizontalAlignment=TextAlignment.Left,
             textString=DynamicSelect("???", String(A_max_plot))),
           Text(
             extent={{50,185},{280,155}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             horizontalAlignment=TextAlignment.Right,
             textString=DynamicSelect("???", String(time)) + " s"),
           Text(
             extent={{-290,288},{-100,263}},
-            lineColor={95,95,95},
+            textColor={95,95,95},
             textString="f_max"),
           Text(
             extent={{-290,243},{-100,213}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="%f_max Hz"),
           Text(
             extent={{-90,288},{100,263}},
-            lineColor={95,95,95},
+            textColor={95,95,95},
             textString="f_resolution"),
           Rectangle(
             extent={{-90,258},{100,208}},
@@ -75,7 +75,7 @@ package ChecksInFixedWindow_withFFT
             borderPattern=BorderPattern.Sunken),
           Text(
             extent={{-90,243},{100,213}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             fillColor={255,0,0},
             fillPattern=FillPattern.Solid,
             textString="%f_resolution Hz")}),

--- a/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
+++ b/Modelica_Requirements/ChecksInFixedWindow_withFFT.mo
@@ -1137,7 +1137,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
 </html>"));
     end maxAmplitudeCurveForIcon;
 
-    function saveFFTonFile "Save FFT computation on file"
+    impure function saveFFTonFile "Save FFT computation on file"
        import Modelica.Utilities.Streams.print;
        input String resultDirectory "Directory where results shall be stored";
        input String filePrefix
@@ -1211,7 +1211,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
 </html>"));
     end set_u;
 
-    function fftScaled "Compute scaled FFT"
+    impure function fftScaled "Compute scaled FFT"
       import Modelica.Utilities.Streams.print;
 
       input Real u_buf[:] "Signal for which FFT shall be computed; (size(u_buf,1) MUST be EVEN and should be an integer multiple of 2,3,5, that is size(u_buf,1) = 2^a*3^b*5^c, with a,b,c Integer >= 0)";
@@ -1275,7 +1275,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
 </html>"));
     end fftScaled;
 
-    function removeFFTresultFiles
+    impure function removeFFTresultFiles
       "Remove FFT results files of previous simulation runs of the current model (if they exist)"
       import Modelica.Utilities.Internal.FileSystem;
       import Modelica.Utilities.Strings;
@@ -1284,7 +1284,7 @@ As can be seen, the first FFT fulfills the check (THD &lt; THDmax), whereas the 
       input String resultDirectory
         "Existing directory where the results are stored";
     protected
-      function removeFFTresultFiles2
+      impure function removeFFTresultFiles2
          input String directory
           "Existing directory where the results are stored";
       protected

--- a/Modelica_Requirements/ChecksInSlidingWindow.mo
+++ b/Modelica_Requirements/ChecksInSlidingWindow.mo
@@ -9,7 +9,7 @@ package ChecksInSlidingWindow
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithPropertyOutput;
 
-    parameter Modelica.SIunits.Time lowerLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time lowerLimit(min=Modelica.Constants.eps)
       "In sliding time window, maxDuration(check=true) >= lowerLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput maxDuration(final unit="s")
@@ -18,7 +18,7 @@ package ChecksInSlidingWindow
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_first;
+    discrete Modelica.Units.SI.Time t_first;
     Boolean first;
 
   initial equation
@@ -122,7 +122,7 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithPropertyOutput;
 
-    parameter Modelica.SIunits.Time lowerLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time lowerLimit(min=Modelica.Constants.eps)
       "In sliding time window, accumulatedDuration(check=true) >= lowerLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput accumulatedDuration(final unit="s")
@@ -131,7 +131,7 @@ results in
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_first;
+    discrete Modelica.Units.SI.Time t_first;
     Boolean first;
 
   initial equation
@@ -233,7 +233,7 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithBooleanOutput;
 
-    parameter Modelica.SIunits.Time lowerLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time lowerLimit(min=Modelica.Constants.eps)
       "In sliding time window, accumulatedDuration(check=true) >= lowerLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput accumulatedDuration(final unit="s")
@@ -330,7 +330,7 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithBooleanOutput;
 
-    parameter Modelica.SIunits.Time upperLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time upperLimit(min=Modelica.Constants.eps)
       "In sliding time window, maxDuration(check=true) <= upperLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput maxDuration(final unit="s")
@@ -430,7 +430,7 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithBooleanOutput;
 
-    parameter Modelica.SIunits.Time upperLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time upperLimit(min=Modelica.Constants.eps)
       "In sliding time window, accumulatedDuration(check=true) <= upperLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput accumulatedDuration(final unit="s")
@@ -531,9 +531,9 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithPropertyOutput;
 
-    parameter Modelica.SIunits.Time lowerLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time lowerLimit(min=Modelica.Constants.eps)
       "In sliding time window, maxDuration(check=true) >= lowerLimit required";
-    parameter Modelica.SIunits.Time upperLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time upperLimit(min=Modelica.Constants.eps)
       "In sliding time window, maxDuration(check=true) <= upperLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput maxDuration(final unit="s")
@@ -542,7 +542,7 @@ results in
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_first;
+    discrete Modelica.Units.SI.Time t_first;
     Boolean first;
 
   initial equation
@@ -645,9 +645,9 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithPropertyOutput;
 
-    parameter Modelica.SIunits.Time lowerLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time lowerLimit(min=Modelica.Constants.eps)
       "In sliding time window, maxDuration(check=true) >= lowerLimit required";
-    parameter Modelica.SIunits.Time upperLimit(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time upperLimit(min=Modelica.Constants.eps)
       "In sliding time window, maxDuration(check=true) <= upperLimit required";
 
     Modelica.Blocks.Interfaces.RealOutput accumulatedDuration(final unit="s")
@@ -656,7 +656,7 @@ results in
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_first;
+    discrete Modelica.Units.SI.Time t_first;
     Boolean first;
 
   initial equation
@@ -769,8 +769,8 @@ results in
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_first;
-    discrete Modelica.SIunits.Time t_next
+    discrete Modelica.Units.SI.Time t_first;
+    discrete Modelica.Units.SI.Time t_next
       "Next time instant where a rising edge of check is leaving the sliding time window";
     Boolean first;
     Boolean checkRising;
@@ -885,7 +885,7 @@ results in
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_next
+    discrete Modelica.Units.SI.Time t_next
       "Next time instant where a rising edge of check is leaving the sliding time window";
     Boolean checkRising;
 
@@ -983,8 +983,8 @@ results in
 
   protected
     SlidingWindow.Buffer buffer "Buffer for sliding window";
-    discrete Modelica.SIunits.Time t_first;
-    discrete Modelica.SIunits.Time t_next
+    discrete Modelica.Units.SI.Time t_first;
+    discrete Modelica.Units.SI.Time t_next
       "Next time instant where a rising edge of check is leaving the sliding time window";
     Boolean first;
     Boolean checkRising;
@@ -1092,7 +1092,7 @@ results in
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithBooleanOutput;
 
-    parameter Modelica.SIunits.Frequency freqHzMeanMax(min=0.0)
+    parameter Modelica.Units.SI.Frequency freqHzMeanMax(min=0.0)
       "Maximum allowed mean frequency of check in sliding time window";
     Modelica.Blocks.Interfaces.RealOutput freqHzMean(final quantity="Frequency",final unit="Hz")
       "Mean frequency of check in sliding time window"
@@ -1100,8 +1100,8 @@ results in
   protected
     function meanFrequency "Return mean frequency"
        input Integer nCrossing "Number of crossing edges in the last window";
-       input Modelica.SIunits.Time window "Length of sliding time window";
-       output Modelica.SIunits.Frequency freqHzMean
+      input Modelica.Units.SI.Time window "Length of sliding time window";
+      output Modelica.Units.SI.Frequency freqHzMean
         "Mean frequency in sliding time window";
     algorithm
        freqHzMean :=if nCrossing > 1 then 1/(window/((nCrossing - 1)/2)) else 0;
@@ -1110,7 +1110,7 @@ results in
     SlidingWindow.Buffer buffer "Buffer for sliding window";
     constant Real eps = 100*Modelica.Constants.eps
       "Small number to guard against division of zero";
-    Modelica.SIunits.Time t_next
+    Modelica.Units.SI.Time t_next
       "Next time instant where a rising edge of check is leaving the sliding time window";
     Integer nCrossing;
     Boolean checkChanging;
@@ -1234,7 +1234,7 @@ rising edges of check into account.
     import Modelica_Requirements.Internal.SlidingWindow;
     extends Interfaces.PartialCheckInSlidingWindowWithBooleanOutput;
 
-    parameter Modelica.SIunits.Frequency freqHzMeanMax(min=0.0)
+    parameter Modelica.Units.SI.Frequency freqHzMeanMax(min=0.0)
       "Maximum allowed mean frequency of rising edges in sliding time window";
     Modelica.Blocks.Interfaces.RealOutput freqHzMean(final quantity="Frequency",final unit="Hz")
       "Mean frequency of the rising edges in sliding time window"
@@ -1242,8 +1242,8 @@ rising edges of check into account.
   protected
     function meanFrequency "Return mean frequency"
        input Integer nRising "Number of rising edges in the last window";
-       input Modelica.SIunits.Time window "Length of sliding time window";
-       output Modelica.SIunits.Frequency freqHzMean
+      input Modelica.Units.SI.Time window "Length of sliding time window";
+      output Modelica.Units.SI.Frequency freqHzMean
         "Mean frequency in sliding time window";
     algorithm
        freqHzMean :=if nRising > 1 then 1/(window/(nRising - 1)) else 0;
@@ -1252,7 +1252,7 @@ rising edges of check into account.
     SlidingWindow.Buffer buffer "Buffer for sliding window";
     constant Real eps = 100*Modelica.Constants.eps
       "Small number to guard against division of zero";
-    Modelica.SIunits.Time t_next
+    Modelica.Units.SI.Time t_next
       "Next time instant where a rising edge of check is leaving the sliding time window";
     Integer nRising;
     Boolean checkRising;
@@ -1361,7 +1361,7 @@ results in
   block MaxIncrease
     "In every sliding time window, the increase of the input is limited"
 
-    parameter Modelica.SIunits.Time window(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time window(min=Modelica.Constants.eps)
       "Length of sliding time window (> 0)";
     parameter Real upperLimit(min=Modelica.Constants.eps)
       "In sliding time window, increase <= upperLimit of input u required";
@@ -1500,7 +1500,7 @@ results in
   block MaxPercentageIncrease
     "In every sliding time window, the percentage increase of the input is limited"
 
-    parameter Modelica.SIunits.Time window(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time window(min=Modelica.Constants.eps)
       "Length of sliding time window (> 0)";
     parameter Real upperPercentageLimit(min=Modelica.Constants.eps)
       "(in [%]) In sliding time window, percentageIncrease <= upperPercentageLimit of input u required";

--- a/Modelica_Requirements/ChecksInSlidingWindow.mo
+++ b/Modelica_Requirements/ChecksInSlidingWindow.mo
@@ -865,8 +865,28 @@ results in
 
     checkRising = edge(check);
     when {checkRising, time >= pre(t_next)} then
-       buffer = if checkRising then SlidingWindow.push(pre(buffer),time) else
-                                    SlidingWindow.removeOldest(pre(buffer), time);
+       buffer = if checkRising then
+          SlidingWindow.push(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time)
+        else
+          SlidingWindow.removeOldest(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time);
        nRising = SlidingWindow.numberOfValues(buffer);
        t_next = SlidingWindow.nextLeaving(buffer, time);
        y = if nRising >= nRisingMin then Property.Satisfied else
@@ -970,8 +990,28 @@ results in
   equation
     checkRising = edge(check);
     when {checkRising, time >= pre(t_next)} then
-       buffer = if checkRising then SlidingWindow.push(pre(buffer),time) else
-                                    SlidingWindow.removeOldest(pre(buffer), time);
+       buffer = if checkRising then
+        SlidingWindow.push(
+          Modelica_Requirements.Internal.SlidingWindow.Buffer(
+            T=pre(buffer.T),
+            t0=pre(buffer.t0),
+            t=pre(buffer.t),
+            b=pre(buffer.b),
+            first=pre(buffer.first),
+            last=pre(buffer.last),
+            nElem=pre(buffer.nElem)),
+          time)
+        else
+        SlidingWindow.removeOldest(
+          Modelica_Requirements.Internal.SlidingWindow.Buffer(
+            T=pre(buffer.T),
+            t0=pre(buffer.t0),
+            t=pre(buffer.t),
+            b=pre(buffer.b),
+            first=pre(buffer.first),
+            last=pre(buffer.last),
+            nElem=pre(buffer.nElem)),
+          time);
        nRising = SlidingWindow.numberOfValues(buffer);
        t_next = SlidingWindow.nextLeaving(buffer, time);
        y = nRising <= nRisingMax;
@@ -1082,8 +1122,28 @@ results in
 
     checkRising = edge(check);
     when {checkRising, time >= pre(t_next)} then
-       buffer = if checkRising then SlidingWindow.push(pre(buffer),time) else
-                                    SlidingWindow.removeOldest(pre(buffer), time);
+       buffer = if checkRising then
+          SlidingWindow.push(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time)
+        else
+          SlidingWindow.removeOldest(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time);
        nRising = SlidingWindow.numberOfValues(buffer);
        t_next = SlidingWindow.nextLeaving(buffer, time);
        y = if nRising >= nRisingMin and nRising <= nRisingMax then Property.Satisfied else
@@ -1196,8 +1256,28 @@ results in
   equation
     checkChanging = change(check);
     when {checkChanging, time >= pre(t_next)} then
-       buffer = if checkChanging then SlidingWindow.push(pre(buffer),time) else
-                   SlidingWindow.removeOldest(pre(buffer), time);
+       buffer = if checkChanging then
+        SlidingWindow.push(
+          Modelica_Requirements.Internal.SlidingWindow.Buffer(
+            T=pre(buffer.T),
+            t0=pre(buffer.t0),
+            t=pre(buffer.t),
+            b=pre(buffer.b),
+            first=pre(buffer.first),
+            last=pre(buffer.last),
+            nElem=pre(buffer.nElem)),
+          time)
+        else
+          SlidingWindow.removeOldest(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time);
        nCrossing = SlidingWindow.numberOfValues(buffer);
        freqHzMean = meanFrequency(nCrossing, window);
        t_next = SlidingWindow.nextLeaving(buffer, time);
@@ -1338,8 +1418,28 @@ rising edges of check into account.
   equation
     checkRising = edge(check);
     when {checkRising, time >= pre(t_next)} then
-       buffer = if checkRising then SlidingWindow.push(pre(buffer),time) else
-                   SlidingWindow.removeOldest(pre(buffer), time);
+       buffer = if checkRising then
+          SlidingWindow.push(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time)
+        else
+          SlidingWindow.removeOldest(
+            Modelica_Requirements.Internal.SlidingWindow.Buffer(
+              T=pre(buffer.T),
+              t0=pre(buffer.t0),
+              t=pre(buffer.t),
+              b=pre(buffer.b),
+              first=pre(buffer.first),
+              last=pre(buffer.last),
+              nElem=pre(buffer.nElem)),
+            time);
        nRising = SlidingWindow.numberOfValues(buffer);
        freqHzMean = meanFrequency(nRising, window);
        t_next = SlidingWindow.nextLeaving(buffer, time);

--- a/Modelica_Requirements/ChecksInSlidingWindow.mo
+++ b/Modelica_Requirements/ChecksInSlidingWindow.mo
@@ -38,7 +38,17 @@ package ChecksInSlidingWindow
     end when;
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     maxDuration = SlidingWindow.maxDuration(buffer, time, check);
@@ -60,12 +70,12 @@ time duration where the Boolean input <b>check</b> was permanently true (= maxDu
 must be &ge; parameter <b>lowerLimit</b>.
 Whenever this property is fulfilled, Property output y = Satisfied.
 If this property is not fulfilled at the end of a sliding time window,
-y = Violated (exception: before the end of the first time window, 
+y = Violated (exception: before the end of the first time window,
 y = Undecided):
 </p>
 
 <blockquote><pre>
-y =  if maxDuration &ge; lowerLimit then Satisfied else 
+y =  if maxDuration &ge; lowerLimit then Satisfied else
     (if first then Undecided else Violated);
 </pre></blockquote>
 
@@ -151,7 +161,17 @@ results in
     end when;
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     accumulatedDuration = SlidingWindow.accumulatedDuration(buffer, time, check);
@@ -173,12 +193,12 @@ time duration where the Boolean input <b>check</b> was true (= accumulatedDurati
 must be &ge; parameter <b>lowerLimit</b>.
 Whenever this property is fulfilled, Property output y = Satisfied.
 If this property is not fulfilled at the end of a sliding time window,
-y = Violated (exception: before the end of the first time window, 
+y = Violated (exception: before the end of the first time window,
 y = Undecided):
 </p>
 
 <blockquote><pre>
-y =  if accumulatedDuration &ge; lowerLimit then Satisfied else 
+y =  if accumulatedDuration &ge; lowerLimit then Satisfied else
     (if first then Undecided else Violated);
 </pre></blockquote>
 
@@ -251,7 +271,17 @@ results in
     assert(lowerLimit < window, "lowerLimit < window required");
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     accumulatedDuration = SlidingWindow.accumulatedDuration(buffer, time, check);
@@ -276,7 +306,7 @@ y = false (even at the first window):
 </p>
 
 <blockquote><pre>
-y =  if accumulatedDuration &ge; lowerLimit then Satisfied else 
+y =  if accumulatedDuration &ge; lowerLimit then Satisfied else
     (if first then Undecided else Violated);
 </pre></blockquote>
 
@@ -348,7 +378,17 @@ results in
     assert(upperLimit < window, "upperLimit < window required");
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     maxDuration = SlidingWindow.maxDuration(buffer, time, check);
@@ -448,7 +488,17 @@ results in
     assert(upperLimit < window, "upperLimit < window required");
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     accumulatedDuration = SlidingWindow.accumulatedDuration(buffer, time, check);
@@ -563,7 +613,17 @@ results in
     end when;
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     maxDuration = SlidingWindow.maxDuration(buffer, time, check);
@@ -585,12 +645,12 @@ time duration where the Boolean input <b>check</b> was permanently true (= maxDu
 must be &ge; parameter <b>lowerLimit</b> and &le; parameter <b>upperLimit</b>.
 Whenever this property is fulfilled, Property output y = Satisfied.
 If this property is not fulfilled at the end of a sliding time window,
-y = Violated (exception: before the end of the first time window, 
+y = Violated (exception: before the end of the first time window,
 y = Undecided provided maxDuration &le; lowerLimit):
 </p>
 
 <blockquote><pre>
-y =  if maxDuration &ge; lowerLimit and maxDuration &le; upperLimit then Satisfied else 
+y =  if maxDuration &ge; lowerLimit and maxDuration &le; upperLimit then Satisfied else
     (if first and maxDuration &le; upperLimit then Undecided else Violated);
 </pre></blockquote>
 
@@ -677,7 +737,17 @@ results in
     end when;
 
     when change(check) then
-       buffer = SlidingWindow.push(pre(buffer), time, check);
+      buffer = SlidingWindow.push(
+        Modelica_Requirements.Internal.SlidingWindow.Buffer(
+          T=pre(buffer.T),
+          t0=pre(buffer.t0),
+          t=pre(buffer.t),
+          b=pre(buffer.b),
+          first=pre(buffer.first),
+          last=pre(buffer.last),
+          nElem=pre(buffer.nElem)),
+        time,
+        check);
     end when;
 
     accumulatedDuration = SlidingWindow.accumulatedDuration(buffer, time, check);
@@ -699,12 +769,12 @@ time duration where the Boolean input <b>check</b> was true (= accumulatedDurati
 must be &ge; parameter <b>lowerLimit</b> and &le; parameter <b>upperLimit</b>.
 Whenever this property is fulfilled, Property output y = Satisfied.
 If this property is not fulfilled at the end of a sliding time window,
-y = Violated (exception: before the end of the first time window, 
+y = Violated (exception: before the end of the first time window,
 y = Undecided provided maxDuration &le; lowerLimit):
 </p>
 
 <blockquote><pre>
-y =  if accumulatedDuration &ge; lowerLimit and accumulatedDuration &le; upperLimit then Satisfied else 
+y =  if accumulatedDuration &ge; lowerLimit and accumulatedDuration &le; upperLimit then Satisfied else
     (if first and accumulatedDuration &le; upperLimit then Undecided else Violated);
 </pre></blockquote>
 
@@ -817,12 +887,12 @@ or rising edges of the Boolean input <b>check</b> (= nRising)
 must be &ge; parameter <b>nRisingMin</b>.
 Whenever this property is fulfilled, Property output y = Satisfied.
 If this property is not fulfilled at the end of a sliding time window,
-Property output y = Violated (exception: before the end of the first time window, 
+Property output y = Violated (exception: before the end of the first time window,
 y = Undecided):
 </p>
 
 <blockquote><pre>
-y =  if nRising &ge; nRisingMin then Satisfied else 
+y =  if nRising &ge; nRisingMin then Satisfied else
     (if first then Undecided else Violated);
 </pre></blockquote>
 
@@ -1034,12 +1104,12 @@ or rising edges of the Boolean input <b>check</b> (= nRising)
 must be &ge; parameter <b>nRisingMin</b> and &le; parameter <b>nRisingMax</b>.
 Whenever this property is fulfilled, Property output y = Satisfied.
 If this property is not fulfilled at the end of a sliding time window,
-Property output y = Violated (exception: before the end of the first time window, 
+Property output y = Violated (exception: before the end of the first time window,
 y = Undecided provided nRising &le; nRisingMax):
 </p>
 
 <blockquote><pre>
-y =  if nRising &ge; nRisingMin and nRising &le; nRisingMax then Satisfied else 
+y =  if nRising &ge; nRisingMin and nRising &le; nRisingMax then Satisfied else
     (if first and nRising &le; nRisingMax then Undecided else Violated);
 </pre></blockquote>
 
@@ -1145,7 +1215,7 @@ freqLimited = <b>MaxFrequency</b>(check=..., window=..., freqHzMeanMax=...).y;
 
 <p>
 In any (sliding) time window of length <b>window</b>,
-the mean frequency of the Boolean input <b>check</b> 
+the mean frequency of the Boolean input <b>check</b>
 is limited by <b>freqHzMeanMax</b>. With T the time period for
 a rising, falling and rising edge of check, the frequency is defined
 as freqHz = 1/T. Therefore, in any sliding window the
@@ -1164,9 +1234,9 @@ freqHzMean &le; freqHzMax
 
 <p>
 where nCrossing is the number of crossing edges of check in the last time window
-of length window. The mean frequency over the sliding time window 
+of length window. The mean frequency over the sliding time window
 is also provided as additional output
-signal <b>freqHzMean</b>. 
+signal <b>freqHzMean</b>.
 If the mean frequency is not larger as freqHzMeanMax, output
 <b>y</b> is set to true, otherwise to y = false.
 </p>
@@ -1287,7 +1357,7 @@ freqLimited = <b>MaxRisingFrequency</b>(check=..., window=..., freqHzMeanMax=...
 
 <p>
 In any (sliding) time window of length <b>window</b>,
-the mean frequency of the rising edges of Boolean input <b>check</b> 
+the mean frequency of the rising edges of Boolean input <b>check</b>
 is limited by <b>freqHzMeanMax</b>. Therefore, in any sliding window the
 following constraint shall hold:
 </p>
@@ -1304,9 +1374,9 @@ freqHzMean &le; freqHzMax
 
 <p>
 where nRising is the number of rising edges of check in the last time window
-of length window. The mean frequency over the sliding time window 
+of length window. The mean frequency over the sliding time window
 is also provided as additional output
-signal <b>freqHzMean</b>. 
+signal <b>freqHzMean</b>.
 If the mean frequency is not larger as freqHzMeanMax, output
 <b>y</b> is set to true, otherwise to y = false.
 </p>
@@ -1467,7 +1537,7 @@ otherwise y = false:
 <p>
 Hereby it is assumed that u(t-window) = u(t<sub>0</sub>) for
 t<sub>0</sub> &le; t &lt; t<sub>0</sub> + window, where t<sub>0</sub> is the
-start time of the simulation. 
+start time of the simulation.
 </p>
 
 <h4>Example</h4>
@@ -1676,7 +1746,7 @@ All blocks of this library have the following interface:
 <li> Real input <b>window</b> is the length of the sliding time window in seconds.
      A check is performed conceptually in every interval [time-window, time].</li>
 
-<li> Property output <b>y</b> is of enumeration type 
+<li> Property output <b>y</b> is of enumeration type
      <a href=\"modelica://Modelica_Requirements.Types.Property\">Property</a>.
      If the check is successful, y = Property.Satisfied. If the check fails,
      y = Property.Violated. If neither of the two properties hold

--- a/Modelica_Requirements/Examples/AirCircuitSystem.mo
+++ b/Modelica_Requirements/Examples/AirCircuitSystem.mo
@@ -110,14 +110,12 @@ package AirCircuitSystem
                 extent={{86,14},{96,-19}},
                 lineColor={0,0,0},
                 fillColor={0,0,0},
-                fillPattern=FillPattern.Solid,
-                visible=port_b_exposesState),
+                fillPattern=FillPattern.Solid),
               Ellipse(
                 extent={{-22,14},{-12,-19}},
                 lineColor={0,0,0},
                 fillColor={0,0,0},
-                fillPattern=FillPattern.Solid,
-                visible=port_b_exposesState)}));
+                fillPattern=FillPattern.Solid)}));
       end PipeRequirements;
 
       block PipeNodeRequirements "Requirements for a a node of a pipe"
@@ -174,14 +172,13 @@ of a pipe shall be between
                 extent={{46,54},{56,21}},
                 lineColor={0,0,0},
                 fillColor={0,0,0},
-                fillPattern=FillPattern.Solid,
-                visible=port_b_exposesState),
+                fillPattern=FillPattern.Solid),
               Ellipse(
                 extent={{-62,54},{-52,21}},
                 lineColor={0,0,0},
                 fillColor={0,0,0},
-                fillPattern=FillPattern.Solid,
-                visible=port_b_exposesState),   Line(
+                fillPattern=FillPattern.Solid),
+              Line(
                 points={{-18,-52},{0,-72},{12,-20}},
                 color={0,127,0},
                 smooth=Smooth.None,

--- a/Modelica_Requirements/Examples/AirCircuitSystem.mo
+++ b/Modelica_Requirements/Examples/AirCircuitSystem.mo
@@ -1,4 +1,4 @@
-﻿within Modelica_Requirements.Examples;
+within Modelica_Requirements.Examples;
 package AirCircuitSystem
   "Simple air circuit example system to demonstrate requirements definition, binding and checking"
   extends Modelica.Icons.ExamplesPackage;
@@ -68,8 +68,9 @@ package AirCircuitSystem
 
         record Medium "Observation variables from a medium"
           extends Modelica.Icons.Record;
-          Modelica.SIunits.Pressure p "Medium pressure" annotation(Dialog);
-          Modelica.SIunits.Temperature T "Medium temperature" annotation(Dialog);
+          Modelica.Units.SI.Pressure p "Medium pressure" annotation (Dialog);
+          Modelica.Units.SI.Temperature T "Medium temperature"
+            annotation (Dialog);
         end Medium;
 
         record MediumVector
@@ -82,11 +83,11 @@ package AirCircuitSystem
       block PipeRequirements "Requirements for a Pipe"
          extends Modelica_Requirements.Interfaces.PartialRequirements;
 
-         parameter Modelica.SIunits.Pressure pMax= 1e5
+        parameter Modelica.Units.SI.Pressure pMax=1e5
           "Maximal allowed pressure";
-         parameter Modelica.SIunits.Temperature Tmin = 255
+        parameter Modelica.Units.SI.Temperature Tmin=255
           "Minimum pipe temperature";
-         parameter Modelica.SIunits.Temperature Tmax = 300
+        parameter Modelica.Units.SI.Temperature Tmax=300
           "Maximum pipe temperature";
 
         input Records.MediumVector observation
@@ -121,11 +122,11 @@ package AirCircuitSystem
 
       block PipeNodeRequirements "Requirements for a a node of a pipe"
          extends Modelica.Blocks.Icons.Block;
-         parameter Modelica.SIunits.Pressure pMax= 1e5
+        parameter Modelica.Units.SI.Pressure pMax=1e5
           "Maximal allowed pressure";
-         parameter Modelica.SIunits.Temperature Tmin = 255
+        parameter Modelica.Units.SI.Temperature Tmin=255
           "Minimum pipe temperature";
-         parameter Modelica.SIunits.Temperature Tmax = 300
+        parameter Modelica.Units.SI.Temperature Tmax=300
           "Maximum pipe temperature";
 
         input Records.Medium observation

--- a/Modelica_Requirements/Examples/AirCircuitSystem.mo
+++ b/Modelica_Requirements/Examples/AirCircuitSystem.mo
@@ -197,6 +197,7 @@ of a pipe shall be between
 
       function PipeObservation_from_DynamicPipe
         "Map DynamicPipe variables to Pipe observations record"
+        extends Modelica.Icons.Function;
         import  Modelica_Requirements.Examples.AirCircuitSystem.Components.*;
         input Requirements.Records.MediumVector dynamicPipe
           "Observation variables from a DynamicPipe";

--- a/Modelica_Requirements/Examples/AircraftRequirements/LimitedCabinAltitudeRateOfChange.mo
+++ b/Modelica_Requirements/Examples/AircraftRequirements/LimitedCabinAltitudeRateOfChange.mo
@@ -13,7 +13,7 @@ pressure domain, more than 5s.")
 
   Modelica_Requirements.SignalAnalysis.ExactDerivative derP
     annotation (Placement(transformation(extent={{-36,60},{-16,80}})));
-  Modelica.Blocks.Sources.Clock clock
+  Modelica.Blocks.Sources.ContinuousClock clock
     annotation (Placement(transformation(extent={{-72,-3},{-60,9}})));
   Modelica_Requirements.ChecksInFixedWindow.MaxDuration maxDuration1(check=
         true, durationMax(displayUnit="s") = 5)

--- a/Modelica_Requirements/Examples/AircraftRequirements/MaximumCabinTemperatureIncrease.mo
+++ b/Modelica_Requirements/Examples/AircraftRequirements/MaximumCabinTemperatureIncrease.mo
@@ -1,4 +1,4 @@
-﻿within Modelica_Requirements.Examples.AircraftRequirements;
+within Modelica_Requirements.Examples.AircraftRequirements;
 model MaximumCabinTemperatureIncrease
   "Requirement: The temperature increase of the cabin area is limited to ensure passenger comfort"
    extends Modelica.Icons.Example;

--- a/Modelica_Requirements/Examples/AircraftRequirements/PreventHeatExchangerClogging.mo
+++ b/Modelica_Requirements/Examples/AircraftRequirements/PreventHeatExchangerClogging.mo
@@ -4,7 +4,7 @@ model PreventHeatExchangerClogging
    extends Modelica.Icons.Example;
    import Modelica_Requirements.LogicalFunctions.*;
 
-  parameter Modelica.SIunits.Mass Mmax= 8e-4;
+  parameter Modelica.Units.SI.Mass Mmax=8e-4;
 
   inner Modelica_Requirements.Verify.PrintViolations printViolations
     annotation (Placement(transformation(extent={{-88,14},{-74,28}})));

--- a/Modelica_Requirements/Examples/Elementary.mo
+++ b/Modelica_Requirements/Examples/Elementary.mo
@@ -712,12 +712,12 @@ results in
       Modelica_Requirements.ChecksInFixedWindow.MaxRisingFrequency maxFrequency1(
           freqHzMax=3, check=crossing.y)
                        annotation (Placement(transformation(extent={{-40,40},{0,60}})));
-      Modelica_Requirements.Sources.RealExpression expr1(y=sin(2*pi*(if time <= 5
-             then 2 elseif time <= 10 then 4 elseif time <= 15 then 2 else 0)*time))
+      Modelica_Requirements.Sources.RealExpression expr1(y=sin(2*pi*(if time < 5
+             then 2 elseif time < 10 then 4 elseif time < 15 then 2 else 0)*time))
         annotation (Placement(transformation(extent={{-92,10},{16,30}})));
     equation
       connect(condition.y, maxFrequency1.condition)
-        annotation (Line(points={{-59,50},{-42,50},{-42,50.1}}, color={255,0,255}));
+        annotation (Line(points={{-59,50},{-42,50},{-42,50}},   color={255,0,255}));
       connect(expr1.y, crossing.u)
         annotation (Line(points={{18.7,20},{26,20},{34,20}},
                                                            color={0,0,127}));
@@ -2070,9 +2070,8 @@ results in
         freqHzMeanMax=3,
         window=2)
         annotation (Placement(transformation(extent={{-60,40},{-20,60}})));
-      Modelica_Requirements.Sources.RealExpression expr1(y=sin(2*pi*(if time
-             <= 5 then 2 elseif time <= 10 then 4 elseif time <= 15 then 2
-             else 0)*time))
+      Modelica_Requirements.Sources.RealExpression expr1(
+        y=sin(2*pi*(if time < 5 then 2 elseif time < 10 then 4 elseif time < 15 then 2 else 0)*time))
         annotation (Placement(transformation(extent={{-88,10},{20,30}})));
     equation
       connect(expr1.y, crossing.u)
@@ -2124,9 +2123,8 @@ more precise as using the <a href=\"modelica://Modelica_Requirements.Examples.El
         freqHzMeanMax=3,
         window=2)
         annotation (Placement(transformation(extent={{-60,40},{-20,60}})));
-      Modelica_Requirements.Sources.RealExpression expr1(y=sin(2*pi*(if time
-             <= 5 then 2 elseif time <= 10 then 4 elseif time <= 15 then 2
-             else 0)*time))
+      Modelica_Requirements.Sources.RealExpression expr1(
+        y=sin(2*pi*(if time < 5 then 2 elseif time < 10 then 4 elseif time < 15 then 2 else 0)*time))
         annotation (Placement(transformation(extent={{-88,10},{20,30}})));
     equation
       connect(expr1.y, crossing.u)
@@ -2922,7 +2920,7 @@ results in
         annotation (Placement(transformation(extent={{-60,-20},{-20,0}})));
       Modelica_Requirements.Sources.IntegerExpression expr2(y=integer(time))
         annotation (Placement(transformation(extent={{-60,-40},{-20,-20}})));
-      Modelica_Requirements.Sources.BooleanExpression expr3(y=time > 1 and time < 3)
+      Modelica_Requirements.Sources.BooleanExpression expr3(y=time >= 1 and time < 3)
         annotation (Placement(transformation(extent={{-60,-60},{-20,-40}})));
       Modelica_Requirements.Sources.RealConstant const1(c=1.234)
         annotation (Placement(transformation(extent={{-60,60},{-40,80}})));

--- a/Modelica_Requirements/Examples/Elementary.mo
+++ b/Modelica_Requirements/Examples/Elementary.mo
@@ -1125,7 +1125,7 @@ Simulating this examples results in
 
 <p>
 As can be seen, the simulation is terminate (via instance <b>terminate1</b> of block 
-<a href=\"Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
+<a href=\"modelica://Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
 the FFT has been computed (signaled via the falling edge of FFT_computation).
 Since all FFT amplitudes between 0 &le; f &le; min(f_max, maxAmplitude[end,1]) are below the maximally allowed limit,
 the block returns Property.Satisfied.
@@ -1323,7 +1323,7 @@ Simulating this examples results in
 
 <p>
 As can be seen, the simulation is terminate (via instance <b>terminate1</b> of block 
-<a href=\"Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
+<a href=\"modelica://Modelica_Requirements.LogicalBlocks.FallingEdgeTerminate\">FallingEdgeTerminate</a>) once
 the FFT has been computed (signaled via the falling edge of FFT_computation).
 Since all FFT amplitudes between 0 &le; f &le; min(f_max, maxAmplitude[end,1]) are below the maximally allowed limit,
 the block returns Property.Satisfied.

--- a/Modelica_Requirements/Examples/Elementary.mo
+++ b/Modelica_Requirements/Examples/Elementary.mo
@@ -1061,10 +1061,10 @@ Note, that the point is outside of the domain defined by the polygon if distance
           f_resolution=0.2,
           maxAmplitude=[0,6; 1,6; 2,4; 3,1.5; 4,1.5])
           annotation (Placement(transformation(extent={{8,0},{68,60}})));
-        Modelica.Blocks.Sources.Sine sine2(amplitude=3, freqHz=2)
-          annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
-        Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, freqHz=3)
-          annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
+      Modelica.Blocks.Sources.Sine sine2(amplitude=3, f=2)
+        annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
+      Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, f=3)
+        annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
         Modelica.Blocks.Sources.Constant const(k=5)
           annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
         Modelica.Blocks.Math.MultiSum multiSum(nu=3)
@@ -1164,14 +1164,17 @@ A plot of the FFT result file is shown in the next figure:
           f_max=6,
           maxAmplitude=[0,6; 1,6; 2,4; 3,1.5; 10,1.5])
           annotation (Placement(transformation(extent={{20,0},{80,60}})));
-        Modelica.Blocks.Sources.Sine sine2(amplitude=3, freqHz=2)
-          annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
-        Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, freqHz=3)
-          annotation (Placement(transformation(extent={{-80,-24},{-60,-4}})));
+      Modelica.Blocks.Sources.Sine sine2(amplitude=3, f=2)
+        annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
+      Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, f=3)
+        annotation (Placement(transformation(extent={{-80,-24},{-60,-4}})));
         Modelica.Blocks.Sources.Constant const(k=5)
           annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
-        Modelica.Blocks.Sources.Sine sine5(freqHz=5,startTime=7,amplitude=2)
-          annotation (Placement(transformation(extent={{-80,-56},{-60,-36}})));
+      Modelica.Blocks.Sources.Sine sine5(
+        f=5,
+        startTime=7,
+        amplitude=2)
+        annotation (Placement(transformation(extent={{-80,-56},{-60,-36}})));
         Modelica.Blocks.Math.MultiSum multiSum(nu=4)
           annotation (Placement(transformation(extent={{-36,24},{-24,36}})));
         Modelica.Blocks.Sources.BooleanTable booleanTable(table={1,1.5,9,9.5})
@@ -1255,10 +1258,10 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
           f_base=2,
           maxAmplitude=[0,120; 1,120; 2,100; 3,50; 4,50])
           annotation (Placement(transformation(extent={{4,0},{64,60}})));
-        Modelica.Blocks.Sources.Sine sine2(amplitude=3, freqHz=2)
-          annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
-        Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, freqHz=3)
-          annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
+      Modelica.Blocks.Sources.Sine sine2(amplitude=3, f=2)
+        annotation (Placement(transformation(extent={{-80,0},{-60,20}})));
+      Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, f=3)
+        annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
         Modelica.Blocks.Sources.Constant const(k=3)
           annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
         Modelica.Blocks.Math.MultiSum multiSum(nu=3)
@@ -1360,14 +1363,17 @@ A plot of the FFT result file is shown in the next figure:
           f_base=2,
           maxAmplitude=[0,120; 1,120; 2,100; 3,50; 10,50])
           annotation (Placement(transformation(extent={{20,0},{80,60}})));
-        Modelica.Blocks.Sources.Sine sine2(amplitude=3, freqHz=2)
-          annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
-        Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, freqHz=3)
-          annotation (Placement(transformation(extent={{-80,-24},{-60,-4}})));
+      Modelica.Blocks.Sources.Sine sine2(amplitude=3, f=2)
+        annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
+      Modelica.Blocks.Sources.Sine sine3(amplitude=1.5, f=3)
+        annotation (Placement(transformation(extent={{-80,-24},{-60,-4}})));
         Modelica.Blocks.Sources.Constant const(k=3)
           annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
-        Modelica.Blocks.Sources.Sine sine5(freqHz=5,startTime=7,amplitude=2)
-          annotation (Placement(transformation(extent={{-80,-56},{-60,-36}})));
+      Modelica.Blocks.Sources.Sine sine5(
+        f=5,
+        startTime=7,
+        amplitude=2)
+        annotation (Placement(transformation(extent={{-80,-56},{-60,-36}})));
         Modelica.Blocks.Math.MultiSum multiSum(nu=4)
           annotation (Placement(transformation(extent={{-36,24},{-24,36}})));
         Modelica.Blocks.Sources.BooleanTable booleanTable(table={1,1.5,9,9.5})
@@ -1450,22 +1456,22 @@ As can be seen, the first FFT fulfills the check (scaledDistance = 0), whereas t
         Modelica_Requirements.ChecksInFixedWindow_withFFT.MaxTotalHarmonicDistortion
           maxTHD1(f_resolution=0.2, f_base=2)
           annotation (Placement(transformation(extent={{-2,0},{58,60}})));
-        Modelica.Blocks.Sources.Sine sine1(amplitude=3, freqHz=2)
-          annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
-        Modelica.Blocks.Sources.Sine sine2(               freqHz=4, amplitude=0.2)
-          annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
+      Modelica.Blocks.Sources.Sine sine1(amplitude=3, f=2)
+        annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
+      Modelica.Blocks.Sources.Sine sine2(f=4, amplitude=0.2)
+        annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
         Modelica.Blocks.Sources.Constant const(k=2.5)
           annotation (Placement(transformation(extent={{-80,70},{-60,90}})));
         Modelica.Blocks.Math.MultiSum multiSum(nu=6)
           annotation (Placement(transformation(extent={{-36,24},{-24,36}})));
         Modelica_Requirements.Sources.BooleanConstant const1
           annotation (Placement(transformation(extent={{-40,60},{-20,80}})));
-        Modelica.Blocks.Sources.Sine sine3(               freqHz=6, amplitude=0.15)
-          annotation (Placement(transformation(extent={{-80,-26},{-60,-6}})));
-        Modelica.Blocks.Sources.Sine sine4(                freqHz=8, amplitude=0.1)
-          annotation (Placement(transformation(extent={{-14,-40},{-34,-20}})));
-        Modelica.Blocks.Sources.Sine sine5(                freqHz=10, amplitude=0.08)
-          annotation (Placement(transformation(extent={{-14,-6},{-34,14}})));
+      Modelica.Blocks.Sources.Sine sine3(f=6, amplitude=0.15)
+        annotation (Placement(transformation(extent={{-80,-26},{-60,-6}})));
+      Modelica.Blocks.Sources.Sine sine4(f=8, amplitude=0.1)
+        annotation (Placement(transformation(extent={{-14,-40},{-34,-20}})));
+      Modelica.Blocks.Sources.Sine sine5(f=10, amplitude=0.08)
+        annotation (Placement(transformation(extent={{-14,-6},{-34,14}})));
       equation
         connect(const.y, multiSum.u[1]) annotation (Line(points={{-59,80},{-46,80},{-46,
                 33.5},{-36,33.5}},            color={0,0,127}));
@@ -1550,23 +1556,23 @@ A plot of the FFT result file is shown in the next figure:
           maxTHD1(f_resolution=0.2, f_base=2,
           THDmax=0.1)
           annotation (Placement(transformation(extent={{20,0},{80,60}})));
-        Modelica.Blocks.Sources.Sine sine1(amplitude=3, freqHz=2)
-          annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
-        Modelica.Blocks.Sources.Sine sine2(               freqHz=4, amplitude=0.2)
-          annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
+      Modelica.Blocks.Sources.Sine sine1(amplitude=3, f=2)
+        annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
+      Modelica.Blocks.Sources.Sine sine2(f=4, amplitude=0.2)
+        annotation (Placement(transformation(extent={{-80,8},{-60,28}})));
         Modelica.Blocks.Sources.Constant const(k=2.5)
           annotation (Placement(transformation(extent={{-80,70},{-60,90}})));
         Modelica.Blocks.Math.MultiSum multiSum(nu=6)
           annotation (Placement(transformation(extent={{-36,24},{-24,36}})));
-        Modelica.Blocks.Sources.Sine sine3(               freqHz=6,
-          amplitude=0.3,
-          startTime=7)
-          annotation (Placement(transformation(extent={{-80,-26},{-60,-6}})));
-        Modelica.Blocks.Sources.Sine sine4(amplitude=0.15, freqHz=8)
-          annotation (Placement(transformation(extent={{0,-34},{-20,-14}})));
-        Modelica.Blocks.Sources.Sine sine5(                freqHz=10, amplitude=
-             0.1)
-          annotation (Placement(transformation(extent={{0,0},{-20,20}})));
+      Modelica.Blocks.Sources.Sine sine3(
+        f=6,
+        amplitude=0.3,
+        startTime=7)
+        annotation (Placement(transformation(extent={{-80,-26},{-60,-6}})));
+      Modelica.Blocks.Sources.Sine sine4(amplitude=0.15, f=8)
+        annotation (Placement(transformation(extent={{0,-34},{-20,-14}})));
+      Modelica.Blocks.Sources.Sine sine5(f=10, amplitude=0.1)
+        annotation (Placement(transformation(extent={{0,0},{-20,20}})));
         Modelica.Blocks.Sources.BooleanTable booleanTable(table={1,1.5,9,9.5})
           annotation (Placement(transformation(extent={{-32,60},{-12,80}})));
       equation
@@ -2251,7 +2257,7 @@ results in
         annotation (Placement(transformation(extent={{-40,-4},{-20,16}})));
       Modelica.Blocks.Sources.Sine sine(
         amplitude=2,
-        freqHz=1,
+        f=1,
         phase=0.78539816339745)
         annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
       Modelica_Requirements.SignalAnalysis.ApproximateDerivativeWithWindow
@@ -2313,7 +2319,7 @@ needs some time until the approximation of the derivative is fine.
       "Example for Integrator (output is the integral over the input, as long as input active is true)"
       extends Modelica.Icons.Example;
 
-      Modelica.Blocks.Sources.Sine sine(freqHz=0.3, offset=2)
+      Modelica.Blocks.Sources.Sine sine(f=0.3, offset=2)
         annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
       Modelica.Blocks.Sources.BooleanPulse pulse(period=2, startTime=1)
         annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
@@ -2356,7 +2362,7 @@ results in
       "Example for MovingAverage (output is the continuous moving average of the input, as long as input active is true)"
       extends Modelica.Icons.Example;
 
-      Modelica.Blocks.Sources.Sine sine(freqHz=0.3, offset=2)
+      Modelica.Blocks.Sources.Sine sine(f=0.3, offset=2)
         annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
       Modelica.Blocks.Sources.BooleanPulse pulse(          startTime=1, period=3)
         annotation (Placement(transformation(extent={{-40,-40},{-20,-20}})));
@@ -2439,7 +2445,7 @@ results in
       "Example for CrossingMonitoring (output is true for a positive threshold crossing of the input and false for a negative threshold crossing)"
       extends Modelica.Icons.Example;
 
-      Modelica.Blocks.Sources.Sine sine(freqHz=2)
+      Modelica.Blocks.Sources.Sine sine(f=2)
         annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
       Modelica_Requirements.SignalAnalysis.CrossingMonitoring crossingMon1(
           threshold=0.5)
@@ -2571,7 +2577,7 @@ results in
 
       Modelica_Requirements.LogicalBlocks.GreaterThreshold gt1(threshold=0.5)
         annotation (Placement(transformation(extent={{-40,40},{0,60}})));
-      Modelica.Blocks.Sources.Sine sine(amplitude=2, freqHz=1)
+      Modelica.Blocks.Sources.Sine sine(amplitude=2, f=1)
         annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
       Modelica_Requirements.LogicalBlocks.GreaterEqualThreshold ge1(threshold=
             0.5)

--- a/Modelica_Requirements/Examples/MotorsWithLosses.mo
+++ b/Modelica_Requirements/Examples/MotorsWithLosses.mo
@@ -25,13 +25,13 @@ package MotorsWithLosses
       "Signals observed from a DC motor as needed by DCMotorRequirements block"
        extends Modelica_Requirements.Interfaces.PartialWatching;
 
-       parameter Modelica.SIunits.Voltage VaNominal;
-       parameter Modelica.SIunits.Current IaNominal;
-       parameter Modelica.SIunits.AngularVelocity wNominal;
+      parameter Modelica.Units.SI.Voltage VaNominal;
+      parameter Modelica.Units.SI.Current IaNominal;
+      parameter Modelica.Units.SI.AngularVelocity wNominal;
 
-       Modelica.SIunits.Voltage v annotation(Dialog);
-       Modelica.SIunits.Current i annotation(Dialog);
-       Modelica.SIunits.AngularVelocity w annotation(Dialog);
+      Modelica.Units.SI.Voltage v annotation (Dialog);
+      Modelica.Units.SI.Current i annotation (Dialog);
+      Modelica.Units.SI.AngularVelocity w annotation (Dialog);
     end DCMotorWatching;
 
     block DCMotorRequirements "Requirements for one DC Motor"
@@ -90,16 +90,16 @@ package MotorsWithLosses
     protected
      record InertiaData
         "Data needed from Modelica.Mechanics.Rotational.Components.Inertia"
-       Modelica.SIunits.AngularVelocity w;
+        Modelica.Units.SI.AngularVelocity w;
      end InertiaData;
 
      record MotorData
         "Data needed Modelica.Electrical.Machines.BasicMachines.DCMachines.DC_PermanentMagnet"
-       parameter Modelica.SIunits.Voltage VaNominal;
-       parameter Modelica.SIunits.Current IaNominal;
-       parameter Modelica.SIunits.AngularVelocity wNominal;
-       Modelica.SIunits.Voltage va;
-       Modelica.SIunits.Current ia;
+        parameter Modelica.Units.SI.Voltage VaNominal;
+        parameter Modelica.Units.SI.Current IaNominal;
+        parameter Modelica.Units.SI.AngularVelocity wNominal;
+        Modelica.Units.SI.Voltage va;
+        Modelica.Units.SI.Current ia;
        InertiaData inertiaRotor;
      end MotorData;
 

--- a/Modelica_Requirements/Examples/SimplePumpingSystem.mo
+++ b/Modelica_Requirements/Examples/SimplePumpingSystem.mo
@@ -79,23 +79,26 @@ Simulate for 2000 s. When the valve is opened at time t=200, the pump starts tur
            extends Modelica.Icons.Package;
          record Tank "Observation variables from a tank"
            extends Modelica.Icons.Record;
-           Modelica.SIunits.Height level "Tank level" annotation(Dialog);
+          Modelica.Units.SI.Height level "Tank level" annotation (Dialog);
          end Tank;
 
          record Pump "Observation variables from a pump"
-            import NonSI = Modelica.SIunits.Conversions.NonSIunits;
+            import NonSI = Modelica.Units.NonSI;
             extends Modelica.Icons.Record;
 
             NonSI.AngularVelocity_rpm speed "Pump speed";
-            Modelica.SIunits.AbsolutePressure p_port_a "Pressure at port_a" annotation(Dialog);
-            Modelica.SIunits.AbsolutePressure p_port_b "Pressure at port_b" annotation(Dialog);
+          Modelica.Units.SI.AbsolutePressure p_port_a "Pressure at port_a"
+            annotation (Dialog);
+          Modelica.Units.SI.AbsolutePressure p_port_b "Pressure at port_b"
+            annotation (Dialog);
          end Pump;
 
          record Source "Observation variables from a source component"
-            import NonSI = Modelica.SIunits.Conversions.NonSIunits;
+            import NonSI = Modelica.Units.NonSI;
             extends Modelica.Icons.Record;
 
-            Modelica.SIunits.AbsolutePressure p[:] "Pressures at vector port" annotation(Dialog);
+          Modelica.Units.SI.AbsolutePressure p[:] "Pressures at vector port"
+            annotation (Dialog);
          end Source;
       end Records;
        extends Modelica.Icons.Package;
@@ -103,11 +106,12 @@ Simulate for 2000 s. When the valve is opened at time t=200, the pump starts tur
       block TankRequirements "Requirements for a Tank"
         extends Modelica_Requirements.Interfaces.PartialRequirements;
 
-        parameter Modelica.SIunits.Height levelMax=2.21 "Maximum allowed level";
-        parameter Modelica.SIunits.Height levelMin=1.8 "Minimum allowed level";
-        parameter Modelica.SIunits.Height limLevel=2.0
+        parameter Modelica.Units.SI.Height levelMax=2.21
+          "Maximum allowed level";
+        parameter Modelica.Units.SI.Height levelMin=1.8 "Minimum allowed level";
+        parameter Modelica.Units.SI.Height limLevel=2.0
           "Level cannot be lower as LimLevel for more as LimDuration";
-        parameter Modelica.SIunits.Time limDuration=300
+        parameter Modelica.Units.SI.Time limDuration=300
           "Maximum allowed duration for LimLevel";
 
         input Records.Tank observation
@@ -160,11 +164,11 @@ Simulate for 2000 s. When the valve is opened at time t=200, the pump starts tur
       end TankRequirements;
 
       block PumpRequirements "Requirements for one pump"
-        import NonSI = Modelica.SIunits.Conversions.NonSIunits;
+        import NonSI = Modelica.Units.NonSI;
         extends Modelica_Requirements.Interfaces.PartialRequirements;
 
         parameter Real max_rpm(unit="rev/min") = 1000 "Maximum pump speed";
-        parameter Modelica.SIunits.Pressure p_min = 100 "Cavitation pressure";
+        parameter Modelica.Units.SI.Pressure p_min=100 "Cavitation pressure";
 
         input Records.Pump observation
           "Observation variables record from a pump" annotation (Dialog(group=
@@ -203,10 +207,10 @@ Simulate for 2000 s. When the valve is opened at time t=200, the pump starts tur
       end PumpRequirements;
 
       block SourceRequirements "Requirements for a Source component"
-        import NonSI = Modelica.SIunits.Conversions.NonSIunits;
+        import NonSI = Modelica.Units.NonSI;
         extends Modelica_Requirements.Interfaces.PartialRequirements;
 
-        parameter Modelica.SIunits.Pressure p_min = 100 "Cavitation pressure";
+        parameter Modelica.Units.SI.Pressure p_min=100 "Cavitation pressure";
         input Records.Source observation
           "Observation variables record from a source" annotation (Dialog(group=
                "Observation variables"), Placement(transformation(extent={{-100,
@@ -240,13 +244,13 @@ Simulate for 2000 s. When the valve is opened at time t=200, the pump starts tur
           "Observation variables from a Modelica.Fluid.Interfaces.FluidPort component (only pressure p)"
             extends Modelica.Icons.Record;
 
-            Modelica.SIunits.AbsolutePressure p
+          Modelica.Units.SI.AbsolutePressure p
             "Thermodynamic pressure in the connection point";
          end FluidPort_p;
 
          record PrescribedPump
           "Observation variables from a Modelica.Fluid.Machines.PrescribedPump component"
-            import NonSI = Modelica.SIunits.Conversions.NonSIunits;
+            import NonSI = Modelica.Units.NonSI;
             extends Modelica.Icons.Record;
 
             NonSI.AngularVelocity_rpm N_in "Pump speed";
@@ -256,7 +260,7 @@ Simulate for 2000 s. When the valve is opened at time t=200, the pump starts tur
 
          record PartialSource
           "Observation variables from a model derived from Modelica.Fluid.Sources.BaseClasses.PartialSource"
-            import NonSI = Modelica.SIunits.Conversions.NonSIunits;
+            import NonSI = Modelica.Units.NonSI;
             extends Modelica.Icons.Record;
 
             // parameter Integer nPorts=0;

--- a/Modelica_Requirements/Interfaces.mo
+++ b/Modelica_Requirements/Interfaces.mo
@@ -398,7 +398,7 @@ as well as a 3D icon (e.g., used in Blocks.Logical library).
 
   partial block PartialTriggeredMovingWindow
     "Icon and equationns for a block with a trigger signal and a moving time window"
-     parameter Modelica.SIunits.Time T(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time T(min=Modelica.Constants.eps)
       "Length of sliding time window";
 
     Modelica.Blocks.Interfaces.RealInput u "Real input signal"
@@ -497,7 +497,7 @@ as well as a 3D icon (e.g., used in Blocks.Logical library).
 
     input Boolean check(start = false) "Boolean to check"
        annotation(Dialog);
-    parameter Modelica.SIunits.Time window(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time window(min=Modelica.Constants.eps)
       "Length of sliding time window (> 0)";
     Modelica.Blocks.Interfaces.BooleanOutput y
       "= true if property satisfied, otherwise false"
@@ -581,7 +581,7 @@ as well as a 3D icon (e.g., used in Blocks.Logical library).
 
     input Boolean check(start = false) "Boolean to check"
        annotation(Dialog);
-    parameter Modelica.SIunits.Time window(min=Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time window(min=Modelica.Constants.eps)
       "Length of sliding time window (> 0)";
     Modelica_Requirements.Interfaces.PropertyOutput y "Property output signal"
       annotation (Placement(transformation(extent={{200,-10},{220,10}})));

--- a/Modelica_Requirements/Internal.mo
+++ b/Modelica_Requirements/Internal.mo
@@ -10,7 +10,7 @@ package Internal "Library of internal components (should not be directly used)"
      flow Real one "Return 1 (to calculate number of requirement blocks"  annotation(HideResult=true);
   end SortingPort;
 
-  function initializeLogFile
+  impure function initializeLogFile
     "Initialize log file (remove existing file and add a blank line"
      input String logFile;
      input Real dummyInput;
@@ -25,7 +25,7 @@ package Internal "Library of internal components (should not be directly used)"
   annotation(__iti_Impure = true);
   end initializeLogFile;
 
-  function printViolationsToLogFile
+  impure function printViolationsToLogFile
     "Print information about one requirement to log file"
      import Modelica.Utilities.Streams.print;
      input String logFile "Name of log file";
@@ -64,7 +64,7 @@ package Internal "Library of internal components (should not be directly used)"
   annotation(__iti_Impure = true);
   end printViolationsToLogFile;
 
-  function printViolationsToOutput
+  impure function printViolationsToOutput
     "Print violated, untested and satisfied requirements to output window"
      import Modelica.Utilities.Streams.*;
      import Modelica.Utilities.Strings.*;
@@ -401,7 +401,7 @@ package Internal "Library of internal components (should not be directly used)"
      algorithm
      end init;
 
-     function push
+     impure function push
       "Store an element on the sliding window buffer and remove elements that are older as the window length"
         import Modelica.Utilities.Streams.print;
         input Buffer buffer "Memory of sliding window";

--- a/Modelica_Requirements/Internal.mo
+++ b/Modelica_Requirements/Internal.mo
@@ -36,7 +36,7 @@ package Internal "Library of internal components (should not be directly used)"
       "= true, if requirement is violated (at least one failure)";
      input Boolean untested
       "= true, if requirement is untested, otherwise requirement is tested and satisfied";
-     input Modelica.SIunits.Time firstFailureTime
+    input Modelica.Units.SI.Time firstFailureTime
       "Time instant of first failure (if atLeastOneFailure=true)";
      output Real ok "Dummy variable needed for sorting";
   protected
@@ -78,7 +78,7 @@ package Internal "Library of internal components (should not be directly used)"
       "Only provided to guarantee that printViolationsToOutput is called after logFile was generated";
      input Real satisfaction
       "Satisfaction of all requirements in % (0% ... 100%)";
-     input Modelica.SIunits.Time satisfactionTime
+    input Modelica.Units.SI.Time satisfactionTime
       "Input satisfaction is with respect to satisfactionTime";
      input Boolean printViolated = true
       "= true, if violated requirements shall be printed";
@@ -385,10 +385,9 @@ package Internal "Library of internal components (should not be directly used)"
      extends Modelica.Icons.Package;
      constant Integer nBuffer = 20 "Length of buffer";
      record Buffer "Memory of sliding window"
-        Modelica.SIunits.Time T "Length of sliding window";
-        Modelica.SIunits.Time t0
-        "Time instant where sliding time window starts";
-        Modelica.SIunits.Time t[nBuffer] "Time instants";
+      Modelica.Units.SI.Time T "Length of sliding window";
+      Modelica.Units.SI.Time t0 "Time instant where sliding time window starts";
+      Modelica.Units.SI.Time t[nBuffer] "Time instants";
         Boolean b[nBuffer] "Values at corresponding time instants";
         Integer first "Index of first element in buffer";
         Integer last "Index of last element in buffer";
@@ -396,8 +395,8 @@ package Internal "Library of internal components (should not be directly used)"
      end Buffer;
 
      function init "Initialize a sliding window buffer"
-        input Modelica.SIunits.Time T "Length of window";
-        input Modelica.SIunits.Time t0 "Initial time instant";
+      input Modelica.Units.SI.Time T "Length of window";
+      input Modelica.Units.SI.Time t0 "Initial time instant";
         output Buffer buffer = Buffer(T=T, t0=t0, t=fill(0, nBuffer), b=fill(false, nBuffer), first=0, last=0, nElem=0) "Initialized buffer";
      algorithm
      end init;
@@ -412,7 +411,7 @@ package Internal "Library of internal components (should not be directly used)"
         output Buffer newBuffer "Updated memory of sliding window";
     protected
         constant Real eps = 1000*Modelica.Constants.eps;
-        Modelica.SIunits.Time tOld = t - (1-eps)*buffer.T;
+      Modelica.Units.SI.Time tOld=t - (1 - eps)*buffer.T;
         Integer first = buffer.first;
         Integer last = buffer.last;
         Integer nElem = buffer.nElem;
@@ -484,7 +483,7 @@ package Internal "Library of internal components (should not be directly used)"
         output Buffer newBuffer "Updated memory of sliding window";
     protected
         constant Real eps = 1000*Modelica.Constants.eps;
-        Modelica.SIunits.Time tOld = t - (1-eps)*buffer.T;
+      Modelica.Units.SI.Time tOld=t - (1 - eps)*buffer.T;
         Integer first = buffer.first;
         Integer last = buffer.last;
         Integer nElem = buffer.nElem;
@@ -537,7 +536,7 @@ package Internal "Library of internal components (should not be directly used)"
       "Return time instant when the oldest element is leaving the buffer"
         input Buffer buffer "Memory of sliding window";
         input Real t "Actual time instant";
-        output Modelica.SIunits.Time t_next
+      output Modelica.Units.SI.Time t_next
         "Next time instant where the oldest value (t,b) in the buffer is leaving the time window";
      algorithm
         t_next :=if buffer.nElem > 0 then buffer.t[buffer.last] + buffer.T else
@@ -583,7 +582,7 @@ package Internal "Library of internal components (should not be directly used)"
         input Buffer buffer "Memory of sliding window";
         input Integer index(min=1)
         "Index of time value (index >= 1; index=1: first)";
-        output Modelica.SIunits.Time t "Time value at index of buffer";
+      output Modelica.Units.SI.Time t "Time value at index of buffer";
     protected
         Integer first = buffer.first;
         Integer nElem = buffer.nElem;
@@ -608,15 +607,15 @@ package Internal "Library of internal components (should not be directly used)"
      function maxDuration
       "Returns the maximum duration where buffer value is true in the sliding time window"
         input Buffer buffer "Memory of sliding window";
-        input Modelica.SIunits.Time t "Actual time instant";
+      input Modelica.Units.SI.Time t "Actual time instant";
         input Boolean b = false
         "Actual value at t (used if no element is in the buffer)";
-        output Modelica.SIunits.Time duration
+      output Modelica.Units.SI.Time duration
         "Maximum duration where buffer value is true in window";
     protected
-        Modelica.SIunits.Time T = buffer.T;
-        Modelica.SIunits.Time t1;
-        Modelica.SIunits.Time t2;
+      Modelica.Units.SI.Time T=buffer.T;
+      Modelica.Units.SI.Time t1;
+      Modelica.Units.SI.Time t2;
         Integer nElem = buffer.nElem;
         Integer iStart;
      algorithm
@@ -661,15 +660,15 @@ package Internal "Library of internal components (should not be directly used)"
      function accumulatedDuration
       "Returns the accumulated duration where buffer value is true in the sliding time window"
         input Buffer buffer "Memory of sliding window";
-        input Modelica.SIunits.Time t "Actual time instant";
+      input Modelica.Units.SI.Time t "Actual time instant";
         input Boolean b = false
         "Actual value at t (used if no element is in the buffer)";
-        output Modelica.SIunits.Time duration
+      output Modelica.Units.SI.Time duration
         "Accumulated duration where buffer value is true in window";
     protected
-        Modelica.SIunits.Time T = buffer.T;
-        Modelica.SIunits.Time t1;
-        Modelica.SIunits.Time t2;
+      Modelica.Units.SI.Time T=buffer.T;
+      Modelica.Units.SI.Time t1;
+      Modelica.Units.SI.Time t2;
         Integer nElem = buffer.nElem;
         Integer iStart;
      algorithm
@@ -720,7 +719,7 @@ package Internal "Library of internal components (should not be directly used)"
 
     protected
        SlidingWindow.Buffer buffer;
-       Modelica.SIunits.Time duration;
+      Modelica.Units.SI.Time duration;
        constant Real eps = 1e-10;
     algorithm
        buffer :=SlidingWindow.init(4, 0);
@@ -787,7 +786,7 @@ package Internal "Library of internal components (should not be directly used)"
 
     protected
        SlidingWindow.Buffer buffer;
-       Modelica.SIunits.Time duration;
+      Modelica.Units.SI.Time duration;
        constant Real eps = 1e-10;
     algorithm
        buffer :=SlidingWindow.init(4, 0);

--- a/Modelica_Requirements/LogicalBlocks.mo
+++ b/Modelica_Requirements/LogicalBlocks.mo
@@ -457,7 +457,7 @@ This block is demonstrated with example
   block DelayedRising
     "Output y is true after a duration of a rising input edge and false after a falling input edge"
     input Boolean u "Boolean input" annotation(Dialog);
-    parameter Modelica.SIunits.Time duration(start=1)
+    parameter Modelica.Units.SI.Time duration(start=1)
       "Duration after rising edge of u";
     Modelica.Blocks.Interfaces.BooleanOutput y
       "= true, after rising edge of u for given duration"

--- a/Modelica_Requirements/LogicalFunctions.mo
+++ b/Modelica_Requirements/LogicalFunctions.mo
@@ -499,7 +499,7 @@ results in
 <h4>Description</h4>
 <p>
 If condition is true, the function returns check (which must be of type
-<a href=\"Modelica_Requirements.Types.Property\">Property</a>). Otherwise, it returns Undecided.
+<a href=\"modelica://Modelica_Requirements.Types.Property\">Property</a>). Otherwise, it returns Undecided.
 </p>
 
 <h4>Example</h4>

--- a/Modelica_Requirements/LogicalFunctions.mo
+++ b/Modelica_Requirements/LogicalFunctions.mo
@@ -446,7 +446,9 @@ results in
 
 <h4>Description</h4>
 <p>
-If condition is true, the function returns \"<a href=\"Modelica_Requirements.LogicalFunctions.toProperty\">toProperty</a>(check)\" (so either Satisfied or Violated). Otherwise, it returns Undecided. Violated, Undecided, and Satisfied are the elements of enumeration
+If condition is true, the function returns \"<a href=\"Modelica_Requirements.Types.Property\">Property</a>(check)\"
+(so either Satisfied or Violated). Otherwise, it returns Undecided.
+Violated, Undecided, and Satisfied are the elements of enumeration
 <a href=\"modelica://Modelica_Requirements.Types.Property\">Property</a>
 </p>
 

--- a/Modelica_Requirements/LogicalFunctions.mo
+++ b/Modelica_Requirements/LogicalFunctions.mo
@@ -365,7 +365,8 @@ oneTrueElement = oneTrue( b )<br>
      input Boolean u "Boolean to be mapped to Property";
     output Modelica_Requirements.Types.Property y "Boolean as Property";
   algorithm
-     y :=if u then Property.Satisfied else Property.Violated
+     y :=if u then Property.Satisfied else Property.Violated;
+
     annotation (Inline=true, Documentation(info="<html>
 
 <h4>Syntax</h4>

--- a/Modelica_Requirements/LogicalFunctions.mo
+++ b/Modelica_Requirements/LogicalFunctions.mo
@@ -446,7 +446,7 @@ results in
 
 <h4>Description</h4>
 <p>
-If condition is true, the function returns \"<a href=\"Modelica_Requirements.Types.Property\">Property</a>(check)\"
+If condition is true, the function returns \"<a href=\"modelica://Modelica_Requirements.Types.Property\">Property</a>(check)\"
 (so either Satisfied or Violated). Otherwise, it returns Undecided.
 Violated, Undecided, and Satisfied are the elements of enumeration
 <a href=\"modelica://Modelica_Requirements.Types.Property\">Property</a>

--- a/Modelica_Requirements/SignalAnalysis.mo
+++ b/Modelica_Requirements/SignalAnalysis.mo
@@ -89,7 +89,7 @@ needs some time until the approximation of the derivative is fine.
 
   block ApproximateDerivativeWithFilter
     "Output is the filtered derivative of the input (= approximate derivative)"
-    parameter Modelica.SIunits.Frequency f_cut "Cut-off frequency of filter";
+    parameter Modelica.Units.SI.Frequency f_cut "Cut-off frequency of filter";
     parameter Integer order=2 "Order of filter";
 
     Modelica.Blocks.Continuous.Filter filter(
@@ -246,7 +246,7 @@ needs some time until the approximation of the derivative is fine.
 
   block ApproximateDerivativeWithWindow
     "Output is the finite difference quotient of the input (= approximate derivative)"
-    parameter Modelica.SIunits.Time dt(min=10*Modelica.Constants.eps)
+    parameter Modelica.Units.SI.Time dt(min=10*Modelica.Constants.eps)
       "Time difference used for difference quotient";
     Modelica.Blocks.Interfaces.RealInput u
       "Real input signal (shall be differentiated)"

--- a/Modelica_Requirements/TimeLocators.mo
+++ b/Modelica_Requirements/TimeLocators.mo
@@ -3,8 +3,9 @@ package TimeLocators
   "Library of continuous time locators (output is true, if within time locator)"
   extends Modelica.Icons.Package;
   block Every "Output is true, during every interval for a defined duration"
-    parameter Modelica.SIunits.Time interval(start=1) "Length of interval" annotation(Dialog);
-    parameter Modelica.SIunits.Time duration(start=0.5)
+    parameter Modelica.Units.SI.Time interval(start=1) "Length of interval"
+      annotation (Dialog);
+    parameter Modelica.Units.SI.Time duration(start=0.5)
       "Duration within interval (< interval)";
     Modelica.Blocks.Interfaces.BooleanOutput y
       "= true, during every interval for defined duration"
@@ -320,7 +321,7 @@ results in
   block AfterFor
     "Output is true, after rising edge of input for defined duration (flat version)"
     input Boolean u "Boolean input" annotation(Dialog);
-    parameter Modelica.SIunits.Time duration(start=1)
+    parameter Modelica.Units.SI.Time duration(start=1)
       "Duration after rising edge of u";
     Modelica.Blocks.Interfaces.BooleanOutput y
       "= true, after rising edge of u for given duration"

--- a/Modelica_Requirements/Verify.mo
+++ b/Modelica_Requirements/Verify.mo
@@ -236,7 +236,7 @@ Requirement R_Satisfied(property = during(check, check));
                                                       graphics),
       Documentation(info="<html><p>
 This block is used to verify a requirement. The Boolean input signal \"property\" shall always be true.
-This signal is mapped to a 3-valued logic <a href=\"Modelica_Requirements.Types.Property\">Property</a>
+This signal is mapped to a 3-valued logic <a href=\"modelica://Modelica_Requirements.Types.Property\">Property</a>
 (= Property.Satisfied if true and Property.Violated if false).
 </p>
 

--- a/Modelica_Requirements/package.mo
+++ b/Modelica_Requirements/package.mo
@@ -9,7 +9,7 @@ package UsersGuide "User's Guide"
 package ReleaseNotes "Release notes"
   extends Modelica.Icons.ReleaseNotes;
 
-  class Version_0_7_0 "Version 0.7.0 (Feb. 4, 2025)"
+  class Version_0_7_0 "Version 0.7.0 (Feb. 13, 2025)"
   extends Modelica.Icons.ReleaseNotes;
 
     annotation (Documentation(info="<html>
@@ -113,12 +113,11 @@ is simulated.
 </html>"));
 end UsersGuide;
 
-
   annotation (preferredView="info",
   uses(Modelica(version="4.0.0")),
 version="0.7",
-versionDate="2016-06-21",
-dateModified = "2016-06-21 08:44:41Z",
+versionDate="2025-02-13",
+dateModified = "2025-02-13",
 revisionId="$Id:: package.mo 9390 2016-06-21 06:35:11Z #$",
 Documentation(info="<html>
 <p>
@@ -147,7 +146,7 @@ upper-case letters.
 </p>
 
 <p>
-This package uses basically Modelica 4.0.0 language elements and requires at least version 4.0.0 of
+This package uses basically Modelica 3.6 language elements and requires at least version 4.0.0 of
 the Modelica Standard Library.
 Additionally, the Modelica extension is used in some examples (but not outside of examples) to
 pass a model instance as argument to a function (and the function argument is a record).
@@ -192,6 +191,5 @@ https://github.com/modelica-3rdparty/Modelica_Requirements/blob/master/LICENSE</
 <p>
 <b>Copyright &copy; 2014-2016, DLR, Dassault Aviation and UNICAL</b>
 </p>
-</html>")
-);
+</html>"));
 end Modelica_Requirements;

--- a/Modelica_Requirements/package.mo
+++ b/Modelica_Requirements/package.mo
@@ -9,6 +9,16 @@ package UsersGuide "User's Guide"
 package ReleaseNotes "Release notes"
   extends Modelica.Icons.ReleaseNotes;
 
+  class Version_0_7_0 "Version 0.7.0 (Feb. 4, 2025)"
+  extends Modelica.Icons.ReleaseNotes;
+
+    annotation (Documentation(info="<html>
+<p>
+Updated implementation to Modelica 4.0.0.
+</p>
+</html>"));
+  end Version_0_7_0;
+
   class Version_0_6_1 "Version 0.6.1 (Feb. 3, 2025)"
   extends Modelica.Icons.ReleaseNotes;
 
@@ -137,8 +147,8 @@ upper-case letters.
 </p>
 
 <p>
-This package uses basically Modelica 3.2 language elements and requires at least version 3.2.2 of
-the Modelica Standard Library (some parts will not work with 3.2.1 or an earlier version).
+This package uses basically Modelica 4.0.0 language elements and requires at least version 4.0.0 of
+the Modelica Standard Library.
 Additionally, the Modelica extension is used in some examples (but not outside of examples) to
 pass a model instance as argument to a function (and the function argument is a record).
 This feature is used to associate requirements in a reasonably convenient way with
@@ -182,8 +192,6 @@ https://github.com/modelica-3rdparty/Modelica_Requirements/blob/master/LICENSE</
 <p>
 <b>Copyright &copy; 2014-2016, DLR, Dassault Aviation and UNICAL</b>
 </p>
-</html>"),
-  Icon(graphics),
-    conversion(from(version="0.6", script=
-            "modelica://Modelica_Requirements/Resources/ConvertFromModelica_Requirements_0.6.mos")));
+</html>")
+);
 end Modelica_Requirements;

--- a/Modelica_Requirements/package.mo
+++ b/Modelica_Requirements/package.mo
@@ -1,4 +1,4 @@
-﻿within ;
+within ;
 package Modelica_Requirements "Modelica_Requirements (Version 0.6) - Defining requirements formally and checking them when simulating"
   extends Modelica.Icons.Package;
 
@@ -95,9 +95,8 @@ end UsersGuide;
 
 
   annotation (preferredView="info",
-  uses(Modelica(version="3.2.2")),
-version="0.6",
-versionBuild=1,
+  uses(Modelica(version="4.0.0")),
+version="0.7",
 versionDate="2016-06-21",
 dateModified = "2016-06-21 08:44:41Z",
 revisionId="$Id:: package.mo 9390 2016-06-21 06:35:11Z #$",
@@ -174,5 +173,7 @@ https://www.Modelica.org/licenses/ModelicaLicense2</a>.</i>
 <b>Copyright &copy; 2014-2016, DLR, Dassault Aviation and UNICAL</b>
 </p>
 </html>"),
-  Icon(graphics));
+  Icon(graphics),
+    conversion(from(version="0.6", script=
+            "modelica://Modelica_Requirements/Resources/ConvertFromModelica_Requirements_0.6.mos")));
 end Modelica_Requirements;


### PR DESCRIPTION
This addresses the following:
- Update library to Modelica 4.0.0
- Increase its version number
- Correct various Modelica syntax errors, such as missing `each`, wrong formatted url
- Correct urls to non-existing classes
- Reformulated event triggering function so that time events rather than state events are triggered
- Reformulated `pre(buffer)` by instantiating a new buffer and applying `pre` to all its data members in the instantiation clause. This is needed for Dymola and OpenModelica to translate the models.
- Corrected graphical annotations (wrong use of `lineColor` as an attribute to `Text`).
- Added missing `impure` to function declarations.
- Removed `visible` attributes that referred non-existent variables.

The `Examples` package now pass the pedantic check in Dymola except for where the Modelica language is violated because of the use of a model as a function input.